### PR TITLE
Support onTap callback

### DIFF
--- a/lib/simple_autocomplete_formfield.dart
+++ b/lib/simple_autocomplete_formfield.dart
@@ -67,6 +67,7 @@ class SimpleAutocompleteFormField<T> extends FormField<T> {
   final FormFieldValidator<T> validator;
   final FormFieldSetter<T> onSaved;
   final ValueChanged<T> onFieldSubmitted;
+  final GestureTapCallback onTap;
   final TextEditingController controller;
   final FocusNode focusNode;
   final InputDecoration decoration;
@@ -98,6 +99,7 @@ class SimpleAutocompleteFormField<T> extends FormField<T> {
       bool autovalidate: false,
       this.validator,
       this.onFieldSubmitted,
+      this.onTap,
       this.onSaved,
 
       // TextFormField properties
@@ -247,6 +249,7 @@ class _SimpleAutocompleteFormFieldState<T> extends FormFieldState<T> {
             return widget.validator(_value);
           }
         },
+        onTap: widget.onTap,
         onSaved: (value) {
           if (widget.onSaved != null) {
             return widget.onSaved(_value);


### PR DESCRIPTION
In some cases this will be useful.
For example in my case I need to scroll the screen to the position of the SimpleAutocompleteFormField widget, but `onSearch` is not a good place to put my callback.